### PR TITLE
building on OS X

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,8 @@ endif()
 
 unset(LIBRARIES)
 
+list(APPEND LIBRARIES "iconv")
+
 if(USE_LZMA)
 	find_package(LZMA REQUIRED)
 	check_link_library(LZMA LZMA_LIBRARIES)


### PR DESCRIPTION
_libiconv and _libiconv_open are used without linking against libiconv.
this causes the linker to fail.

src/util/load.cpp:#include <iconv.h>

it seems that iconv would always need to be linked against, so i put it as the first thing after unsetting the LIBRARIES var.

if this is an OS X specific issue, i can wrap it around an if block.
