### PR TITLE
Fix linking to libiconv on OS where iconv is not bundled with libc.

### DIFF
--- a/cmake/Findiconv.cmake
+++ b/cmake/Findiconv.cmake
@@ -40,6 +40,7 @@ endif()
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(iconv DEFAULT_MSG iconv_INCLUDE_DIR)
 
-if(iconv_FOUND)
+# For some reason, find_package_... uppercases it's first argument. Nice!
+if(ICONV_FOUND)
 	set(iconv_LIBRARIES ${iconv_LIBRARY})
-endif(iconv_FOUND)
+endif(ICONV_FOUND)


### PR DESCRIPTION
Linking fails on OS X (and others possibily) because libiconv is not properly detected. One of the cmake macros (see commit) seems to uppercase it's first argument, leading to ICONV_FOUND being defined instead of iconv_FOUND. Fixing this solved the link problem.
