### PR TITLE
accept --language "all" to extract all localizations at once

### DIFF
--- a/src/cli/extract.cpp
+++ b/src/cli/extract.cpp
@@ -270,7 +270,7 @@ void process_file(const fs::path & file, const extract_options & o) {
 				
 				size_t file_i = files_for_location[location.second][i];
 				
-				if(!o.language.empty() && !info.files[file_i].languages.empty()) {
+				if(!o.language.empty() && !info.files[file_i].languages.empty() && o.language != "all") {
 					if(!setup::expression_match(o.language, info.files[file_i].languages)) {
 						continue;
 					}
@@ -279,6 +279,9 @@ void process_file(const fs::path & file, const extract_options & o) {
 				if(!info.files[file_i].destination.empty()) {
 					std::string path = o.filenames.convert(info.files[file_i].destination);
 					if(!path.empty()) {
+                                                if(o.language == "all" && !info.files[file_i].languages.empty() && info.files[file_i].languages != "english") {
+							path += ('_' + info.files[file_i].languages);
+						}
 						bool filtered = false;
 						bool tokeep = false;
 						BOOST_FOREACH(const Filter & i, includes) {


### PR DESCRIPTION
this predictive no-clobbering is needed to make g-d-p package ArxFatalis localised versions.  

S'il vous plaît, Bitte.

build/innoextract /var/www/ArxFatalis_1.21_MULTILANG.exe  --language all | grep LOC
```
 - "app/LOC.pak" [english] (204 KiB)
 - "app/LOC.pak_french" [french] (212 KiB)
 - "app/LOC.pak_german" [german] (211 KiB)
 - "app/LOC.pak_italian" [italian] (211 KiB)
 - "app/LOC.pak_spanish" [spanish] (163 KiB)
 - "app/LOC.pak_russian" [russian] (181 KiB)
```