### PR TITLE
Fix building in paths that contain regex expressions

### DIFF
--- a/cmake/CreateSourceGroups.cmake
+++ b/cmake/CreateSourceGroups.cmake
@@ -4,7 +4,7 @@
 # that replicate the folder hierarchy on disk
 function(create_source_groups source_files_variable)
 	foreach(source_file ${${source_files_variable}})
-		string( REGEX REPLACE ${CMAKE_CURRENT_SOURCE_DIR} "" relative_directory "${source_file}")
+		string( REPLACE ${CMAKE_CURRENT_SOURCE_DIR} "" relative_directory "${source_file}")
 		string( REGEX REPLACE "[\\\\/][^\\\\/]*$" "" relative_directory "${relative_directory}")
 		string( REGEX REPLACE "^[\\\\/]" "" relative_directory "${relative_directory}")
 		if( WIN32 )


### PR DESCRIPTION
I think doing a normal string replace instead of a regex replace is the correct behavior in this case.