### PR TITLE
Readmever

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -470,6 +470,12 @@ set(MAN_SOURCES VERSION "VERSION" CHANGELOG "CHANGELOG")
 version_file(${MAN_INPUT} ${MAN_FILE} "${MAN_SOURCES}" ".git")
 add_custom_target(manpage ALL DEPENDS ${MAN_FILE})
 
+set(README_INPUT "README.md.in")
+set(README_FILE "README.md")
+set(README_SOURCES VERSION "VERSION")
+version_file(${README_INPUT} ${README_FILE} "${README_SOURCES}" ".git")
+add_custom_target(readme ALL DEPENDS ${README_FILE})
+
 
 # Main targets
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Install options:
 | `CMAKE_INSTALL_PREFIX`      | `/usr/local`         | Where to install innoextract.
 | `CMAKE_INSTALL_BINDIR`      | `bin`                | Location for binaries (relative to prefix).
 | `CMAKE_INSTALL_DATAROOTDIR` | `share`              | Location for data files (relative to prefix).
-| `CMAKE_INSTALL_MANDIR`      | `man`                | Location for man pages (relative to dataroot).
+| `CMAKE_INSTALL_MANDIR`      | `man`                | Location for man pages (relative to datarootdir).
 
 Set options by passing `-D<option>=<value>` to cmake.
 

--- a/README.md.in
+++ b/README.md.in
@@ -83,7 +83,7 @@ Install options:
 | `CMAKE_INSTALL_PREFIX`      | `/usr/local`         | Where to install innoextract.
 | `CMAKE_INSTALL_BINDIR`      | `bin`                | Location for binaries (relative to prefix).
 | `CMAKE_INSTALL_DATAROOTDIR` | `share`              | Location for data files (relative to prefix).
-| `CMAKE_INSTALL_MANDIR`      | `man`                | Location for man pages (relative to dataroot).
+| `CMAKE_INSTALL_MANDIR`      | `man`                | Location for man pages (relative to datarootdir).
 
 Set options by passing `-D<option>=<value>` to cmake.
 

--- a/README.md.in
+++ b/README.md.in
@@ -1,7 +1,7 @@
 
 # innoextract - A tool to unpack installers created by Inno Setup
 
-[Inno Setup](https://jrsoftware.org/isinfo.php) is a tool to create installers for Microsoft Windows applications. innoextract allows to extract such installers under non-Windows systems without running the actual installer using wine. innoextract currently supports installers created by Inno Setup 1.2.10 to 6.0.4.
+[Inno Setup](https://jrsoftware.org/isinfo.php) is a tool to create installers for Microsoft Windows applications. innoextract allows to extract such installers under non-Windows systems without running the actual installer using wine. innoextract currently supports installers created by @VERSION_2@.
 
 In addition to standard Inno Setup installers, innoextract also supports some modified Inno Setup variants including Martijn Laan's My Inno Setup Extensions 3.0.6.1 as well as GOG.com's Inno Setup-based game installers.
 


### PR DESCRIPTION
This updates the supported versions of Inno Setup in the README.md file in the SOURCE directory.  I modified the file in the source directory so git status will show the change.

Note that I had trouble escaping the ${DATAROOTDIR} text in the original README.  Instead I noted that the man dir was relative to datarootdir in the last column, similar to the note about the previous rows being relative to prefix.



