### PR TITLE
Add support for a modified Inno Setup 5.3.10 variant

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,7 @@
 
+innoextract 1.10 (TBD)
+ - Added support for a modified Inno Setup 5.3.10 variant
+
 innoextract 1.9 (2020-08-09)
  - Added preliminary support for Inno Setup 6.1.0
  - Added support for a modified Inno Setup 5.4.2 variant

--- a/src/setup/header.cpp
+++ b/src/setup/header.cpp
@@ -493,10 +493,10 @@ void header::load(std::istream & is, const version & version) {
 		uninstall_display_size = 0;
 	}
 	
-	if(version == INNO_VERSION_EXT(5, 4,  2, 1) || version == INNO_VERSION_EXT(5, 5, 0, 1)) {
+	if(version == INNO_VERSION_EXT(5, 3, 10, 1) || version == INNO_VERSION_EXT(5, 4,  2, 1) || version == INNO_VERSION_EXT(5, 5, 0, 1)) {
 		/*
 		 * This is needed to extract an Inno Setup variant (BlackBox v2?) that uses
-		 * the 5.4.2 or 5.5.0 (unicode) data version string while the format differs:
+		 * the 5.3.10, 5.4.2 or 5.5.0 (unicode) data version string while the format differs:
 		 * The language entries are off by one byte and the EncryptionUsed flag
 		 * gets set while there is no decrypt_dll.
 		 * I'm not sure where exactly this byte goes, but it's after the compression

--- a/src/setup/version.cpp
+++ b/src/setup/version.cpp
@@ -158,7 +158,9 @@ const known_version versions[] = {
 	{ "Inno Setup Setup Data (5.3.9)",                      INNO_VERSION_EXT(5, 3,  9, 0), 0 },
 	{ "Inno Setup Setup Data (5.3.9) (u)",                  INNO_VERSION_EXT(5, 3,  9, 0), version::Unicode },
 	{ "Inno Setup Setup Data (5.3.10)",                     INNO_VERSION_EXT(5, 3, 10, 0), 0 },
-	{ "Inno Setup Setup Data (5.3.10) (u)",                 INNO_VERSION_EXT(5, 3, 10, 0), version::Unicode },
+	{ "Inno Setup Setup Data (5.3.10) (u)", /* ambiguous */ INNO_VERSION_EXT(5, 3, 10, 0), version::Unicode },
+	{ "" /* BlackBox v1? */,                                INNO_VERSION_EXT(5, 3, 10, 1), 0 },
+	{ "" /* BlackBox v1? */,                                INNO_VERSION_EXT(5, 3, 10, 1), version::Unicode },
 	{ "Inno Setup Setup Data (5.4.2)",                      INNO_VERSION_EXT(5, 4,  2, 0), 0 },
 	{ "Inno Setup Setup Data (5.4.2) (u)",  /* ambiguous */ INNO_VERSION_EXT(5, 4,  2, 0), version::Unicode },
 	{ "" /* BlackBox v1? */,                                INNO_VERSION_EXT(5, 4,  2, 1), 0 },
@@ -372,6 +374,11 @@ bool version::is_ambiguous() const {
 	
 	if(value == INNO_VERSION(4, 2, 3)) {
 		// might be either 4.2.3 or 4.2.4
+		return true;
+	}
+	
+	if(value == INNO_VERSION(5, 3, 10)) {
+		// might be either 5.3.10 or 5.3.10.1
 		return true;
 	}
 	


### PR DESCRIPTION
Simple extension like https://github.com/dscharrer/innoextract/commit/0e07acc503d07d985c56e1f2e0ca2a643c771a79 but for 5.3.10 variant.

Fixes https://github.com/dscharrer/innoextract/issues/126