### PR TITLE
Fix build with boost 1.85

### DIFF
--- a/src/stream/slice.cpp
+++ b/src/stream/slice.cpp
@@ -27,6 +27,7 @@
 #include <boost/cstdint.hpp>
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/filesystem/operations.hpp>
+#include <boost/filesystem/directory.hpp>
 #include <boost/range/size.hpp>
 
 #include "util/console.hpp"


### PR DESCRIPTION
As of boost 1.85-beta1, boost/filesystem/directory.hpp is no longer implicitly included by boost/filesystem/operations.hpp. Include it explicitly.