### PR TITLE
CMake: Fix build with Boost 1.89.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -173,13 +173,17 @@ else()
 	set(INNOEXTRACT_HAVE_LZMA 0)
 endif()
 
-find_package(Boost REQUIRED COMPONENTS
+set(BOOST_REQUIRED_COMPONENTS
 	iostreams
 	filesystem
 	date_time
-	system
 	program_options
 )
+find_package(Boost REQUIRED COMPONENTS ${BOOST_REQUIRED_COMPONENTS})
+if(Boost_MAJOR_VERSION EQUAL 1 AND Boost_MINOR_VERSION LESS 69)
+	list(APPEND BOOST_REQUIRED_COMPONENTS system)
+	find_package(Boost REQUIRED COMPONENTS ${BOOST_REQUIRED_COMPONENTS})
+endif()
 list(APPEND LIBRARIES ${Boost_LIBRARIES})
 link_directories(${Boost_LIBRARY_DIRS})
 include_directories(SYSTEM ${Boost_INCLUDE_DIR})


### PR DESCRIPTION
In the upcoming Boost 1.89.0 release, the Boost.System stub library introduced back in 1.69[^1] has been removed (https://github.com/boostorg/system/commit/7a495bb46d7ccd808e4be2a6589260839b0fd3a3), which causes a CMake error.

This PR change using `OPTIONAL_COMPONENTS` is based on upstream recommendation `https://github.com/boostorg/system/issues/132#issuecomment-3146378680` given Boost 1.37 is still allowed.

[^1]: https://www.boost.org/doc/libs/1_69_0/libs/system/doc/html/system.html#changes_in_boost_1_69