### PR TITLE
Add support for Inno Setup 6.4.2 through 6.5.4

### DIFF
--- a/src/setup/header.cpp
+++ b/src/setup/header.cpp
@@ -266,6 +266,16 @@ void header::load(std::istream & is, const version & version) {
 		is >> util::binary_string(architectures_allowed_expr);
 		is >> util::binary_string(architectures_installed_in_64bit_mode_expr);
 	}
+	if(version >= INNO_VERSION(6, 4, 2)) {
+		is >> util::binary_string(close_applications_filter_excludes);
+	} else {
+		close_applications_filter_excludes.clear();
+	}
+	if(version >= INNO_VERSION(6, 5, 0)) {
+		is >> util::binary_string(seven_zip_library_name);
+	} else {
+		seven_zip_library_name.clear();
+	}
 	if(version >= INNO_VERSION(5, 2, 5)) {
 		is >> util::ansi_string(license_text);
 		is >> util::ansi_string(info_before);
@@ -317,7 +327,13 @@ void header::load(std::istream & is, const version & version) {
 	} else {
 		task_count = 0;
 	}
-	
+
+	// NumISSigKeyEntries was added in 6.5.0, placed before directory/file counts
+	if(version >= INNO_VERSION(6, 5, 0)) {
+		// We don't use this count yet, but we need to read it to maintain stream position
+		(void)util::load<boost::uint32_t>(is);
+	}
+
 	directory_count = util::load<boost::uint32_t>(is, version.bits());
 	file_count = util::load<boost::uint32_t>(is, version.bits());
 	data_entry_count = util::load<boost::uint32_t>(is, version.bits());
@@ -762,6 +778,8 @@ void header::decode(util::codepage_id codepage) {
 	util::to_utf8(create_uninstall_registry_key, codepage, &lead_bytes);
 	util::to_utf8(uninstallable, codepage);
 	util::to_utf8(close_applications_filter, codepage);
+	util::to_utf8(close_applications_filter_excludes, codepage);
+	util::to_utf8(seven_zip_library_name, codepage);
 	util::to_utf8(setup_mutex, codepage, &lead_bytes);
 	util::to_utf8(changes_environment, codepage);
 	util::to_utf8(changes_associations, codepage);

--- a/src/setup/header.hpp
+++ b/src/setup/header.hpp
@@ -167,6 +167,8 @@ struct header {
 	std::string changes_associations;
 	std::string architectures_allowed_expr;
 	std::string architectures_installed_in_64bit_mode_expr;
+	std::string close_applications_filter_excludes;
+	std::string seven_zip_library_name;
 	std::string license_text;
 	std::string info_before;
 	std::string info_after;

--- a/src/setup/version.cpp
+++ b/src/setup/version.cpp
@@ -186,6 +186,13 @@ const known_version versions[] = {
 	{ "Inno Setup Setup Data (6.3.0)",                      INNO_VERSION_EXT(6, 3,  0, 0), version::Unicode },
 	{ "Inno Setup Setup Data (6.4.0)",     /* prerelease */ INNO_VERSION_EXT(6, 4,  0, 0), version::Unicode },
 	{ "Inno Setup Setup Data (6.4.0.1)",        /* 6.4.0 */ INNO_VERSION_EXT(6, 4,  0, 1), version::Unicode },
+	{ "Inno Setup Setup Data (6.4.2)",                      INNO_VERSION_EXT(6, 4,  2, 0), version::Unicode },
+	{ "Inno Setup Setup Data (6.4.3)",                      INNO_VERSION_EXT(6, 4,  3, 0), version::Unicode },
+	{ "Inno Setup Setup Data (6.5.0)",                      INNO_VERSION_EXT(6, 5,  0, 0), version::Unicode },
+	{ "Inno Setup Setup Data (6.5.1)",                      INNO_VERSION_EXT(6, 5,  1, 0), version::Unicode },
+	{ "Inno Setup Setup Data (6.5.2)",                      INNO_VERSION_EXT(6, 5,  2, 0), version::Unicode },
+	{ "Inno Setup Setup Data (6.5.3)",                      INNO_VERSION_EXT(6, 5,  3, 0), version::Unicode },
+	{ "Inno Setup Setup Data (6.5.4)",                      INNO_VERSION_EXT(6, 5,  4, 0), version::Unicode },
 };
 
 } // anonymous namespace


### PR DESCRIPTION
Added version strings for Inno Setup 6.4.2, 6.4.3, and 6.5.0-6.5.4.

New fields in header structure:
- close_applications_filter_excludes (added in 6.4.2)
- seven_zip_library_name (added in 6.5.0)
- NumISSigKeyEntries count field (added in 6.5.0) - read to maintain stream position