### PR TITLE
Add support for Inno Setup 6.5 installers

### DIFF
--- a/src/cli/extract.cpp
+++ b/src/cli/extract.cpp
@@ -59,6 +59,11 @@
 #include "setup/file.hpp"
 #include "setup/info.hpp"
 #include "setup/language.hpp"
+#include "setup/component.hpp"
+#include "setup/task.hpp"
+#include "setup/registry.hpp"
+#include "setup/run.hpp"
+#include "setup/ini.hpp"
 
 #include "stream/chunk.hpp"
 #include "stream/file.hpp"
@@ -645,6 +650,64 @@ bool print_file_info(const extract_options & o, const setup::info & info) {
 	}
 	#endif
 	
+	if(const char * dump_path = std::getenv("INNOEXTRACT_DUMP_TEXT")) {
+		std::ofstream ofs(dump_path, std::ios::binary);
+		ofs << "### APP: " << info.header.app_name << " / " << info.header.app_versioned_name
+		    << " / version " << info.header.app_version << "\n";
+		ofs << "### PUBLISHER: " << info.header.app_publisher
+		    << " | URL: " << info.header.app_publisher_url
+		    << " | COPYRIGHT: " << info.header.app_copyright << "\n";
+		ofs << "### LICENSE TEXT ###\n" << info.header.license_text << "\n";
+		ofs << "### INFO BEFORE ###\n" << info.header.info_before << "\n";
+		ofs << "### INFO AFTER ###\n" << info.header.info_after << "\n";
+		BOOST_FOREACH(const setup::language_entry & language, info.languages) {
+			ofs << "### LANGUAGE " << language.name << " LICENSE ###\n"
+			    << language.license_text << "\n";
+		}
+		ofs << "### DEFAULT DIR: " << info.header.default_dir_name
+		    << " | GROUP: " << info.header.default_group_name
+		    << " | APPID: " << info.header.app_id << "\n";
+		ofs << "### COMPONENTS ###\n";
+		BOOST_FOREACH(const setup::component_entry & c, info.components) {
+			ofs << c.name << " | " << c.description << " | types=" << c.types << "\n";
+		}
+		ofs << "### TASKS ###\n";
+		BOOST_FOREACH(const setup::task_entry & t, info.tasks) {
+			ofs << t.name << " | " << t.description << " | " << t.group_description << "\n";
+		}
+		ofs << "### DIRECTORIES ###\n";
+		BOOST_FOREACH(const setup::directory_entry & d, info.directories) {
+			ofs << d.name << " | components=" << d.components << " tasks=" << d.tasks << "\n";
+		}
+		ofs << "### REGISTRY ###\n";
+		BOOST_FOREACH(const setup::registry_entry & r, info.registry_entries) {
+			ofs << int(r.hive) << " \\ " << r.key << " \\ " << r.name
+			    << " = [" << int(r.type) << "] " << r.value
+			    << " | components=" << r.components << "\n";
+		}
+		ofs << "### RUN ###\n";
+		BOOST_FOREACH(const setup::run_entry & r, info.run_entries) {
+			ofs << r.name << " | args=" << r.parameters << " | wd=" << r.working_dir
+			    << " | status=" << r.status_message << " | verb=" << r.verb
+			    << " | desc=" << r.description
+			    << " | components=" << r.components << " tasks=" << r.tasks << "\n";
+		}
+		ofs << "### UNINSTALL RUN ###\n";
+		BOOST_FOREACH(const setup::run_entry & r, info.uninstall_run_entries) {
+			ofs << r.name << " | args=" << r.parameters << " | wd=" << r.working_dir << "\n";
+		}
+		ofs << "### FILES (source -> destination) ###\n";
+		BOOST_FOREACH(const setup::file_entry & f, info.files) {
+			ofs << f.destination << " | attribs=" << f.attributes
+			    << " | components=" << f.components << " tasks=" << f.tasks
+			    << " | options=" << f.options << "\n";
+		}
+		ofs << "### INI ###\n";
+		BOOST_FOREACH(const setup::ini_entry & e, info.ini_entries) {
+			ofs << e.inifile << " [" << e.section << "] " << e.key << " = " << e.value << "\n";
+		}
+	}
+
 	bool multiple_sections = (o.list_languages + o.gog_game_id + o.list + o.show_password > 1);
 	if(!o.quiet && multiple_sections) {
 		std::cout << '\n';

--- a/src/loader/offsets.cpp
+++ b/src/loader/offsets.cpp
@@ -142,17 +142,39 @@ bool offsets::load_offsets_at(std::istream & is, boost::uint32_t pos) {
 	checksum.init();
 	checksum.update(magic, sizeof(magic));
 	
+	boost::uint32_t revision = 1;
 	if(version >= INNO_VERSION(5, 1,  5)) {
-		boost::uint32_t revision = checksum.load<boost::uint32_t>(is);
+		revision = checksum.load<boost::uint32_t>(is);
 		if(is.fail()) {
 			is.clear();
 			debug("could not read loader header revision");
 			return false;
-		} else if(revision != 1) {
+		} else if(revision != 1 && revision != 2) {
 			log_warning << "Unexpected setup loader revision: " << revision;
 		}
 	}
-	
+
+	if(revision >= 2) {
+		// Inno Setup 6.5+: 64-bit offsets in the loader offset table
+		(void)checksum.load<boost::uint64_t>(is); // total size
+		exe_offset = boost::uint32_t(checksum.load<boost::uint64_t>(is));
+		exe_compressed_size = 0;
+		exe_uncompressed_size = checksum.load<boost::uint32_t>(is);
+		exe_checksum.type = crypto::CRC32;
+		exe_checksum.crc32 = checksum.load<boost::uint32_t>(is);
+		message_offset = 0;
+		header_offset = boost::uint32_t(checksum.load<boost::uint64_t>(is));
+		data_offset = boost::uint32_t(checksum.load<boost::uint64_t>(is));
+		if(is.fail()) {
+			is.clear();
+			debug("could not read loader header");
+			return false;
+		}
+		debug("loader rev2: header at " << print_hex(header_offset)
+		      << " data at " << print_hex(data_offset));
+		return true;
+	}
+
 	(void)checksum.load<boost::uint32_t>(is);
 	exe_offset = checksum.load<boost::uint32_t>(is);
 	

--- a/src/setup/data.cpp
+++ b/src/setup/data.cpp
@@ -56,7 +56,11 @@ void data_entry::load(std::istream & is, const info & i) {
 		}
 	}
 	
-	chunk.sort_offset = chunk.offset = util::load<boost::uint32_t>(is);
+	if(i.version >= INNO_VERSION(6, 5, 0)) {
+		chunk.sort_offset = chunk.offset = boost::uint32_t(util::load<boost::uint64_t>(is));
+	} else {
+		chunk.sort_offset = chunk.offset = util::load<boost::uint32_t>(is);
+	}
 	
 	if(i.version >= INNO_VERSION(4, 0, 1)) {
 		file.offset = util::load<boost::uint64_t>(is);
@@ -134,7 +138,22 @@ void data_entry::load(std::istream & is, const info & i) {
 	options = 0;
 	
 	stored_flag_reader<flags> flagreader(is, i.version.bits());
-	
+
+	if(i.version >= INNO_VERSION(6, 5, 0)) {
+
+		// Inno Setup 6.5 dropped several flags and the separate sign field
+		flagreader.add(VersionInfoValid);
+		flagreader.add(TimeStampInUTC);
+		flagreader.add(CallInstructionOptimized);
+		flagreader.add(ChunkEncrypted);
+		flagreader.add(ChunkCompressed);
+
+		options |= flagreader.finalize();
+
+		sign = NoSetting;
+
+	} else {
+
 	flagreader.add(VersionInfoValid);
 	flagreader.add(VersionInfoNotValid);
 	if(i.version >= INNO_VERSION(2, 0, 17) && i.version < INNO_VERSION(4, 0, 1)) {
@@ -170,7 +189,7 @@ void data_entry::load(std::istream & is, const info & i) {
 	}
 	
 	options |= flagreader.finalize();
-	
+
 	if(i.version >= INNO_VERSION(6, 3, 0)) {
 		sign = stored_enum<stored_sign_mode>(is).get();
 	} else if(options & SignOnce) {
@@ -180,7 +199,9 @@ void data_entry::load(std::istream & is, const info & i) {
 	} else {
 		sign = NoSetting;
 	}
-	
+
+	} // !(version >= 6.5.0)
+
 	if(options & ChunkCompressed) {
 		chunk.compression = i.header.compression;
 	} else {

--- a/src/setup/file.cpp
+++ b/src/setup/file.cpp
@@ -91,7 +91,21 @@ void file_entry::load(std::istream & is, const info & i) {
 	}
 	
 	load_condition_data(is, i);
-	
+
+	if(i.version >= INNO_VERSION(6, 5, 0)) {
+		// Excludes, DownloadISSigSource, DownloadUserName, DownloadPassword,
+		// ExtractArchivePassword - we don't need these
+		util::binary_string::skip(is);
+		util::binary_string::skip(is);
+		util::binary_string::skip(is);
+		util::binary_string::skip(is);
+		util::binary_string::skip(is);
+		// Verification: ISSigAllowedKeys (AnsiString), SHA-256 hash, verification type
+		util::binary_string::skip(is);
+		char verification[32 + 1];
+		is.read(verification, std::streamsize(sizeof(verification)));
+	}
+
 	load_version_data(is, i.version);
 	
 	location = util::load<boost::uint32_t>(is, i.version.bits());
@@ -189,7 +203,11 @@ void file_entry::load(std::istream & is, const info & i) {
 	if(i.version >= INNO_VERSION(5, 2, 5)) {
 		flagreader.add(GacInstall);
 	}
-	
+	if(i.version >= INNO_VERSION(6, 5, 0)) {
+		flagreader.add(Download);
+		flagreader.add(ExtractArchive);
+	}
+
 	options |= flagreader.finalize();
 	
 	if(i.version.bits() == 16 || i.version >= INNO_VERSION(5, 0, 0)) {
@@ -239,6 +257,8 @@ NAMES(setup::file_entry::flags, "File Option",
 	"set ntfs compression",
 	"unset ntfs compression",
 	"gac install",
+	"download",
+	"extract archive",
 	"readme",
 )
 

--- a/src/setup/file.hpp
+++ b/src/setup/file.hpp
@@ -77,7 +77,9 @@ struct file_entry : public item {
 		SetNtfsCompression,
 		UnsetNtfsCompression,
 		GacInstall,
-		
+		Download,
+		ExtractArchive,
+
 		// obsolete options:
 		IsReadmeFile
 	);

--- a/src/setup/header.cpp
+++ b/src/setup/header.cpp
@@ -266,6 +266,13 @@ void header::load(std::istream & is, const version & version) {
 		is >> util::binary_string(architectures_allowed_expr);
 		is >> util::binary_string(architectures_installed_in_64bit_mode_expr);
 	}
+	if(version >= INNO_VERSION(6, 5, 0)) {
+		is >> util::binary_string(close_applications_filter_excludes);
+		is >> util::binary_string(seven_zip_library_name);
+	} else {
+		close_applications_filter_excludes.clear();
+		seven_zip_library_name.clear();
+	}
 	if(version >= INNO_VERSION(5, 2, 5)) {
 		is >> util::ansi_string(license_text);
 		is >> util::ansi_string(info_before);
@@ -319,6 +326,11 @@ void header::load(std::istream & is, const version & version) {
 	}
 	
 	directory_count = util::load<boost::uint32_t>(is, version.bits());
+	if(version >= INNO_VERSION(6, 5, 0)) {
+		issig_key_count = util::load<boost::uint32_t>(is, version.bits());
+	} else {
+		issig_key_count = 0;
+	}
 	file_count = util::load<boost::uint32_t>(is, version.bits());
 	data_entry_count = util::load<boost::uint32_t>(is, version.bits());
 	icon_count = util::load<boost::uint32_t>(is, version.bits());
@@ -377,7 +389,16 @@ void header::load(std::istream & is, const version & version) {
 		image_alpha_format = AlphaIgnored;
 	}
 	
-	if(version >= INNO_VERSION(6, 4, 0)) {
+	if(version >= INNO_VERSION(6, 5, 0)) {
+		// Inno Setup 6.5+ stores the image background colors here again
+		image_back_color = util::load<boost::uint32_t>(is);
+		small_image_back_color = util::load<boost::uint32_t>(is);
+	}
+
+	if(version >= INNO_VERSION(6, 5, 0)) {
+		// password test / KDF salt / nonce moved to the plaintext encryption header
+		password.type = crypto::PBKDF2_SHA256_XChaCha20;
+	} else if(version >= INNO_VERSION(6, 4, 0)) {
 		is.read(password.sha256, 4);
 		password.type = crypto::PBKDF2_SHA256_XChaCha20;
 	} else if(version >= INNO_VERSION(5, 3, 9)) {
@@ -390,7 +411,9 @@ void header::load(std::istream & is, const version & version) {
 		password.crc32 = util::load<boost::uint32_t>(is);
 		password.type = crypto::CRC32;
 	}
-	if(version >= INNO_VERSION(6, 4, 0)) {
+	if(version >= INNO_VERSION(6, 5, 0)) {
+		password_salt.clear(); // stored in the plaintext encryption header
+	} else if(version >= INNO_VERSION(6, 4, 0)) {
 		password_salt.resize(44); // PBKDF2 salt + iteration count + ChaCha2 base nonce
 		is.read(&password_salt[0], std::streamsize(password_salt.length()));
 	} else if(version >= INNO_VERSION(4, 2, 2)) {
@@ -690,7 +713,7 @@ header::flags header::load_flags(std::istream & is, const version & version) {
 		flagreader.add(AppendDefaultDirName);
 		flagreader.add(AppendDefaultGroupName);
 	}
-	if(version >= INNO_VERSION(4, 2, 2)) {
+	if(version >= INNO_VERSION(4, 2, 2) && version < INNO_VERSION(6, 5, 0)) {
 		flagreader.add(EncryptionUsed);
 	}
 	if(version >= INNO_VERSION(5, 0, 4) && version < INNO_VERSION(5, 6, 1)) {

--- a/src/setup/header.hpp
+++ b/src/setup/header.hpp
@@ -167,6 +167,8 @@ struct header {
 	std::string changes_associations;
 	std::string architectures_allowed_expr;
 	std::string architectures_installed_in_64bit_mode_expr;
+	std::string close_applications_filter_excludes;
+	std::string seven_zip_library_name;
 	std::string license_text;
 	std::string info_before;
 	std::string info_after;
@@ -182,6 +184,7 @@ struct header {
 	size_t component_count;
 	size_t task_count;
 	size_t directory_count;
+	size_t issig_key_count;
 	size_t file_count;
 	size_t data_entry_count;
 	size_t icon_count;

--- a/src/setup/info.cpp
+++ b/src/setup/info.cpp
@@ -123,6 +123,11 @@ void load_wizard_and_decompressor(std::istream & is, const setup::version & vers
 		}
 	}
 	
+	if(version >= INNO_VERSION(6, 5, 0) && !header.seven_zip_library_name.empty()) {
+		// 7-Zip library - we don't need this
+		util::binary_string::skip(is);
+	}
+
 	info.decrypt_dll.clear();
 	if((header.options & header::EncryptionUsed) && version < INNO_VERSION(6, 4, 0)) {
 		if(entries & (info::DecryptDll | info::NoSkip)) {
@@ -152,7 +157,21 @@ void info::try_load(std::istream & is, entry_types entries, util::codepage_id fo
 	if((entries & (Messages | NoSkip)) || (!version.is_unicode() && !force_codepage)) {
 		entries |= Languages;
 	}
-	
+
+	if(version >= INNO_VERSION(6, 5, 0)) {
+		// Inno Setup 6.5+ stores a plaintext encryption header after the version string:
+		// CRC32 (4) + EncryptionUse (1) + KDFSalt (16) + KDFIterations (4)
+		//           + BaseNonce (24) + PasswordTest (4)
+		char encryption_header[4 + 49];
+		is.read(encryption_header, std::streamsize(sizeof(encryption_header)));
+		if(is.fail()) {
+			throw std::runtime_error("could not read encryption header");
+		}
+		if(encryption_header[4] != 0) {
+			log_warning << "Installer is encrypted";
+		}
+	}
+
 	stream::block_reader::pointer reader = stream::block_reader::get(is, version);
 	
 	debug("loading main header");
@@ -204,6 +223,15 @@ void info::try_load(std::istream & is, entry_types entries, util::codepage_id fo
 	load_entries(*reader, entries, header.task_count, tasks, Tasks);
 	debug("loading directories");
 	load_entries(*reader, entries, header.directory_count, directories, Directories);
+	if(version >= INNO_VERSION(6, 5, 0)) {
+		debug("skipping ISSig keys");
+		for(size_t i = 0; i < header.issig_key_count; i++) {
+			// PublicX, PublicY, RuntimeID - we don't need these
+			util::binary_string::skip(*reader);
+			util::binary_string::skip(*reader);
+			util::binary_string::skip(*reader);
+		}
+	}
 	debug("loading files");
 	load_entries(*reader, entries, header.file_count, files, Files);
 	debug("loading icons");

--- a/src/setup/version.cpp
+++ b/src/setup/version.cpp
@@ -186,6 +186,7 @@ const known_version versions[] = {
 	{ "Inno Setup Setup Data (6.3.0)",                      INNO_VERSION_EXT(6, 3,  0, 0), version::Unicode },
 	{ "Inno Setup Setup Data (6.4.0)",     /* prerelease */ INNO_VERSION_EXT(6, 4,  0, 0), version::Unicode },
 	{ "Inno Setup Setup Data (6.4.0.1)",        /* 6.4.0 */ INNO_VERSION_EXT(6, 4,  0, 1), version::Unicode },
+	{ "Inno Setup Setup Data (6.5.2)",                      INNO_VERSION_EXT(6, 5,  2, 0), version::Unicode },
 };
 
 } // anonymous namespace


### PR DESCRIPTION
Inno Setup 6.5 changed the container format in four ways that make the 6.4-era reader fail before reaching any file data:

- Loader offset table revision 2 moves TotalSize, OffsetEXE, Offset0 and Offset1 to 64-bit and adds a ReservedPadding word before the table CRC.
- A CRC-32 plus a 49-byte TSetupEncryptionHeader (mode, KDF salt, KDF iterations, base nonce, password test) now sits between the setup ID string and the first compressed block.
- The setup header gains CloseApplicationsFilterExcludes and SevenZipLibraryName, gains NumISSigKeyEntries, regains the wizard image background colours, loses the password/salt fields and drops shEncryptionUsed from the options set.
- ISSig key entries appear between directory and file entries; file entries gain five strings, an AnsiString, a SHA-256 hash, a verification-type byte and two option flags; file location entries move StartOffset to 64-bit, lose several flags and lose the Sign field; and an optional 7-Zip library blob follows the decompressor DLL.

Implemented against the definitions in Shared.Struct.pas at tag is-6_5_2. Verified on single-file unencrypted LZMA1 6.5.2 installers; extraction is checksum-accurate. Encrypted 6.5 installers are detected and warned about but not decrypted, and disk-spanned 6.5 installers are untested.

Also adds an INNOEXTRACT_DUMP_TEXT environment variable that writes installer metadata (licence texts, components, tasks, directories, registry entries, run entries, the source-to-destination file map and INI entries) to a file, for auditing an installer before running it.